### PR TITLE
(refacto) Move api secret to env variable

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,7 +4,7 @@ import {formations} from "./data/formations.data.js";
 const app = express()
 const port = 3000
 
-const API_KEY = '395a9cce-6ffc-48b8-8372-b95089c3abc6'
+const API_KEY = process.env.MYAPIKEY
 
 
 app.get('/formations', (req, res) => {


### PR DESCRIPTION
problem:
secret pushed in github

solution:
move secret to env variable with process.env.MYAPIKEY
export MYAPIKEY=ndsvn2g8dnsb9hsg

remark:
We can connect this repo with gitguardian to avoid pushing secret